### PR TITLE
Add Check for Lightbulb in Dropdown

### DIFF
--- a/lightbulb.js
+++ b/lightbulb.js
@@ -106,7 +106,10 @@ $(() => {
     var rawBulb = $('#dropdown').text();
 
     if(rawBulb.trim().length == 0) {
-	    alert('No Bulb Selected');
+
+	const { dialog } = require('electron').remote;
+	dialog.showErrorBox('Whoops!', 'No Lightbulb Was Selected.');
+ 
     } else {
     	let light = new Control(rawBulb.split(": ")[1], {
     	  apply_masks: true,

--- a/lightbulb.js
+++ b/lightbulb.js
@@ -104,19 +104,23 @@ $(() => {
     } = require('magic-home');
     stilllisten = true;
     var rawBulb = $('#dropdown').text();
-    let light = new Control(rawBulb.split(": ")[1], {
-      apply_masks: true,
-      wait_for_reply: false,
-    });
+
+    if(rawBulb.trim().length == 0) {
+	    alert('No Bulb Selected');
+    } else {
+    	let light = new Control(rawBulb.split(": ")[1], {
+    	  apply_masks: true,
+    	  wait_for_reply: false,
+    	});
     // Set any additional parameters like whether or not the controller
     // supports cold_white values.
-    light.queryState(handleError);
-    light.setPower(true).then(success => {
-      startlisten(light);
-      setInterval(function() {
-        changeColor(light);
-      }, 1000);
-    });
+    	light.queryState(handleError);
+    	light.setPower(true).then(success => {
+    	  startlisten(light);
+    	  setInterval(function() {
+    	    changeColor(light);
+    	  }, 1000);});
+    }
   });
   $('#stop').on('click', function(event) {
     stilllisten = false;


### PR DESCRIPTION
This adds a small check when the "Start Listening" button is checked, to see if there is actually a lightbulb selected. It uses native dialog.showErrorBox to alert the user, and then bypasses the bulb commands.